### PR TITLE
Bugfix/cerrar sesión artista

### DIFF
--- a/Obligatorio/codigo/ArenaGestor/ArenaGestor.API/Controllers/SecurityController.cs
+++ b/Obligatorio/codigo/ArenaGestor/ArenaGestor.API/Controllers/SecurityController.cs
@@ -32,7 +32,7 @@ namespace ArenaGestor.API.Controllers
         }
 
         [HttpPost("logout")]
-        [AuthorizationFilter(RoleCode.Administrador, RoleCode.Vendedor, RoleCode.Acomodador, RoleCode.Espectador)]
+        [AuthorizationFilter(RoleCode.Administrador, RoleCode.Vendedor, RoleCode.Acomodador, RoleCode.Espectador, RoleCode.Artista)]
         public IActionResult Logout([FromHeader] string token)
         {
             this.securityService.Logout(token);

--- a/Obligatorio/codigo/ArenaGestor/ArenaGestor.API/Filters/AuthorizationFilter.cs
+++ b/Obligatorio/codigo/ArenaGestor/ArenaGestor.API/Filters/AuthorizationFilter.cs
@@ -11,7 +11,7 @@ namespace ArenaGestor.API.Filters
     public class AuthorizationFilter : Attribute, IAuthorizationFilter
     {
 
-        private readonly RoleCode[] roles;
+        public readonly RoleCode[] roles;
 
         private ISecurityService _securityService;
         public AuthorizationFilter(params RoleCode[] roles)

--- a/Obligatorio/codigo/ArenaGestor/Test/ArenaGestor.APITest/SecurityControllerTest.cs
+++ b/Obligatorio/codigo/ArenaGestor/Test/ArenaGestor.APITest/SecurityControllerTest.cs
@@ -69,14 +69,11 @@ namespace ArenaGestor.APITest
         [TestMethod]
         public void Logout_ShouldHaveCorrectAuthorizationRoles()
         {
-            // Arrange
             var methodInfo = typeof(SecurityController).GetMethod(nameof(SecurityController.Logout));
 
-            // Act
             var authAttributes = methodInfo.GetCustomAttributes(typeof(AuthorizationFilter), true);
             var authFilter = authAttributes[0] as AuthorizationFilter;
 
-            // Assert
             CollectionAssert.AreEquivalent(new[] { RoleCode.Administrador, RoleCode.Vendedor, RoleCode.Acomodador, RoleCode.Espectador, RoleCode.Artista }, authFilter.roles);
         }
     }

--- a/Obligatorio/codigo/ArenaGestor/Test/ArenaGestor.APITest/SecurityControllerTest.cs
+++ b/Obligatorio/codigo/ArenaGestor/Test/ArenaGestor.APITest/SecurityControllerTest.cs
@@ -1,9 +1,12 @@
 ﻿using ArenaGestor.API.Controllers;
+using ArenaGestor.API.Filters;
 using ArenaGestor.APIContracts.Security;
 using ArenaGestor.BusinessInterface;
+using ArenaGestor.Domain;
 using AutoMapper;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 
@@ -62,5 +65,21 @@ namespace ArenaGestor.APITest
             mock.VerifyAll();
             Assert.AreEqual(StatusCodes.Status200OK, statusCode);
         }
+
+        [TestMethod]
+        public void Logout_ShouldHaveCorrectAuthorizationRoles()
+        {
+            // Arrange
+            var methodInfo = typeof(SecurityController).GetMethod(nameof(SecurityController.Logout));
+
+            // Act
+            var authAttributes = methodInfo.GetCustomAttributes(typeof(AuthorizationFilter), true);
+            var authFilter = authAttributes[0] as AuthorizationFilter;
+
+            // Assert
+            CollectionAssert.AreEquivalent(new[] { RoleCode.Administrador, RoleCode.Vendedor, RoleCode.Acomodador, RoleCode.Espectador, RoleCode.Artista }, authFilter.roles);
+        }
     }
 }
+
+


### PR DESCRIPTION
Se arregló el cierre de sesión para los usuarios con el rol de artista. El usuario '[fredy@example.com](mailto:fredy@example.com)' con la contraseña 'test' es uno de ellos.